### PR TITLE
Dependency to git for installing Maildev

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,1 +1,3 @@
-dependencies: []
+dependencies:
+# We need git to install Maildev.
+- dork.shell


### PR DESCRIPTION
currently fails with:
npm ERR! node v5.5.0
npm ERR! npm  v3.3.12
npm ERR! code ENOGIT

npm ERR! not found: git
npm ERR! 
npm ERR! Failed using git.
npm ERR! This is most likely not a problem with npm itself.
npm ERR! Please check if you have git installed and in your PATH.

So I guess we need a dependency to dork.shell which installs git?
